### PR TITLE
Update max kube-version annotation

### DIFF
--- a/charts/elemental/1.0.0/Chart.yaml
+++ b/charts/elemental/1.0.0/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows

--- a/charts/kubewarden/1.0.0/Chart.yaml
+++ b/charts/kubewarden/1.0.0/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows

--- a/charts/kubewarden/1.0.1/Chart.yaml
+++ b/charts/kubewarden/1.0.1/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows

--- a/charts/kubewarden/1.0.2/Chart.yaml
+++ b/charts/kubewarden/1.0.2/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows

--- a/charts/kubewarden/1.0.3/Chart.yaml
+++ b/charts/kubewarden/1.0.3/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows

--- a/index.yaml
+++ b/index.yaml
@@ -3,7 +3,7 @@ entries:
   elemental:
   - annotations:
       catalog.cattle.io/certified: rancher
-      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
       catalog.cattle.io/namespace: cattle-ui-plugin-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/permits-os: linux, windows
@@ -24,7 +24,7 @@ entries:
   kubewarden:
   - annotations:
       catalog.cattle.io/certified: rancher
-      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
       catalog.cattle.io/namespace: cattle-ui-plugin-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/permits-os: linux, windows
@@ -44,7 +44,7 @@ entries:
     version: 1.0.3
   - annotations:
       catalog.cattle.io/certified: rancher
-      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
       catalog.cattle.io/namespace: cattle-ui-plugin-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/permits-os: linux, windows
@@ -64,7 +64,7 @@ entries:
     version: 1.0.2
   - annotations:
       catalog.cattle.io/certified: rancher
-      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
       catalog.cattle.io/namespace: cattle-ui-plugin-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/permits-os: linux, windows
@@ -84,7 +84,7 @@ entries:
     version: 1.0.1
   - annotations:
       catalog.cattle.io/certified: rancher
-      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+      catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
       catalog.cattle.io/namespace: cattle-ui-plugin-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/permits-os: linux, windows


### PR DESCRIPTION
Updates the `catalog.cattle.io/kube-version` annotation for all the charts to have a max version of `1.26.0-0`.

This is just a stop-gap measure until [this issue](https://github.com/rancher/ui-plugin-server/issues/13) is resolved, which is used automatically generate the yaml for each chart.