### PR TITLE
Update sync script with target branch in manifest - add sync workflow

### DIFF
--- a/.github/workflows/sync-extensions.yml
+++ b/.github/workflows/sync-extensions.yml
@@ -1,0 +1,58 @@
+name: Sync and Release Extensions
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - manifest.json
+
+env:
+  ACTIONS_RUNNER_DEBUG: false
+  CI_COMMIT_MESSAGE: CI Build Artifacts
+
+jobs:
+  sync:
+    if: github.repository_owner == 'rancher'
+    name: Sync and Release Extensions
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure Git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.1
+
+      - name: Setup yq
+        uses: chrisdickinson/setup-yq@v1.0.1
+        with:
+          yq-version: v4.34.2
+
+      - name: Run sync script
+        shell: bash
+        id: sync_script
+        run: |
+          chmod +x ./scripts/sync
+          ./scripts/sync
+
+      - name: Commit build
+        run: |
+          git add ./{assets,charts,extensions,icons,index.yaml}
+          git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: ./charts/*
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_SKIP_EXISTING: true

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "extensions": {
     "elemental": {
       "repo": "rancher/elemental-ui",
+      "branch": "main",
       "versions": [
         "1.2.0",
         "1.1.0",
@@ -10,6 +11,7 @@
     },
     "kubewarden": {
       "repo": "kubewarden/ui",
+      "branch": "gh-pages",
       "versions": [
         "1.0.0",
         "1.0.1",

--- a/scripts/sync
+++ b/scripts/sync
@@ -12,25 +12,57 @@ CHECK="\xE2\x9C\x94"
 
 ORG=rancher
 BRANCH=main
+CLEAN=false
 
-while getopts "co:b:" opt; do
-  case $opt in
-    c)
-      rm -rf ./charts
-      rm -rf ./assets
-      rm -rf ./extensions
-      rm -rf ./icons
+usage() {
+  echo "Usage: $0 [<options>]"
+  echo " options:"
+  echo "  [-c | --clean]                   Clean the current extension assets including: ./{charts, assets, extensions, icons}"
+  echo "  [-o | --org] <name>              Specify the organization of the current repository (defaults to 'rancher')"
+  echo "  [-b | --branch] <name>           Specify the destination branch of the extension assets within the current repository (defaults to 'main')"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
       ;;
-    o)
-      ORG="${OPTARG}"
+    -o|--org)
+      if [[ -z $2 || $2 == -* ]]; then
+        echo "Error: Missing argument for $1 option"
+        usage
+      fi
+      ORG="${2}"
+      shift 2
       ;;
-    b)
-      BRANCH="${OPTARG}"
+    -c|--clean)
+      CLEAN=true
+      shift
+      ;;
+    -b|--branch)
+      if [[ -z $2 || $2 == -* ]]; then
+        echo "Error: Missing argument for $1 option"
+        usage
+      fi
+      BRANCH="${2}"
+      shift 2
+      ;;
+    *)
+      echo "Error: Unknown option $1"
+      usage
       ;;
   esac
 done
 
 shift $((OPTIND-1))
+
+if [[ $CLEAN == true ]]; then
+  rm -rf ./charts
+  rm -rf ./assets
+  rm -rf ./extensions
+  rm -rf ./icons
+fi
 
 echo -e "${CYAN}${BOLD}Syncing Extensions${RESET}"
 
@@ -52,17 +84,19 @@ for NAME in ${EXTS}
 do
   echo -e "${CYAN} + Syncing: ${BOLD}${NAME}${RESET}"
 
-  # Make diretories for assets anc charts
+  # Make diretories for assets, charts, and extensions
   mkdir -p ./assets/${NAME}
   mkdir -p ./charts/${NAME}
   mkdir -p ./extensions/${NAME}
 
-  # Get repository name
+  # Get repository name, branch, and versions 
   REPO=$(jq -r ".extensions.${NAME}.repo" manifest.json)
+  EXT_BRANCH=$(jq -r ".extensions.${NAME}.branch" manifest.json)
   VERSIONS=$(jq -r ".extensions.${NAME}.versions[]" manifest.json)
   VFORMAT=$(echo $VERSIONS | tr '\n' ' ')
 
   echo -e "     Repository: ${REPO}"
+  echo -e "     Branch: ${EXT_BRANCH}"
   echo -e "     Versions  : ${VFORMAT}"
   echo ""
 
@@ -70,6 +104,8 @@ do
   rm -rf ./tmp/${NAME}
   pushd tmp > /dev/null
   git clone https://github.com/${REPO}.git ${NAME}
+  cd ${NAME}
+  git checkout ${EXT_BRANCH}
   pwd
   popd > /dev/null
 


### PR DESCRIPTION
Fix https://github.com/rancher/dashboard/issues/9215

This updates the sync script and manifest.json with the requirement to target a branch for each repository listed within the manifest. Also, a workflow has been added to run this sync script automatically when a new version has been added to the manifest.

As with the updates done to the [kubewarden/ui](https://github.com/kubewarden/ui/issues/414) repo and the impending updates to the [rancher/elemental-ui](https://github.com/rancher/elemental-ui/issues/127) repo, the build assets have been moved from the `main` branch to the `gh-pages` branch. 
The script will now checkout the branch listed within a repository's `branch` property ( In the manifest.json, `extensions.<ext-name>.branch` ) - this branch is determined based on where the build assets live.

The sync script can now be automated with the workflow `sync-extensions.yml` added. This will run when a change is detected in the `manifest.json` file within the `main` branch. It is gated to only be ran when the repository owner is `rancher` so it will not be ran on forks. The workflow will run the `sync` script, commit the newly generated files to the main branch, and release the charts for easy consumption. 