### PR TITLE
Add extension catalog image sync script to workflow

### DIFF
--- a/.github/workflows/sync-extensions.yml
+++ b/.github/workflows/sync-extensions.yml
@@ -1,6 +1,8 @@
 name: Sync and Release Extensions
 
 on:
+  release:
+    types: [released]
   push:
     branches:
       - main
@@ -10,21 +12,27 @@ on:
 env:
   ACTIONS_RUNNER_DEBUG: false
   CI_COMMIT_MESSAGE: CI Build Artifacts
+  REGISTRY_URL: ghcr.io
+  REGISTRY_USER: ${{ github.actor }}
 
 jobs:
-  sync:
-    if: github.repository_owner == 'rancher'
-    name: Sync and Release Extensions
+  sync-charts:
+    if: github.repository_owner == 'rancher' && github.ref_type != 'tag'
+    name: Sync and Release Extension Charts
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      actions: write
+      contents: write
+      deployments: write
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Configure Git
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@github.com
       
       - name: Setup Helm
         uses: azure/setup-helm@v3
@@ -36,12 +44,12 @@ jobs:
         with:
           yq-version: v4.34.2
 
-      - name: Run sync script
+      - name: Run sync-charts script
         shell: bash
-        id: sync_script
+        id: sync_charts_script
         run: |
-          chmod +x ./scripts/sync
-          ./scripts/sync
+          chmod +x ./scripts/sync-charts
+          ./scripts/sync-charts
 
       - name: Commit build
         run: |
@@ -56,3 +64,34 @@ jobs:
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           CR_SKIP_EXISTING: true
+
+  sync-catalogs:
+      if: github.repository_owner == 'rancher' && github.ref_type == 'tag'
+      name: Sync and Release Extension Catalog
+      runs-on: ubuntu-latest
+      permissions:
+        actions: write
+        contents: read
+        packages: write
+
+      steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ evn.REGISTRY_USER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync Catalog Image with Registry
+        id: sync_catalog_script
+        run: |
+          chmod +x ./scripts/sync-catalogs
+          ./scripts/sync-catalogs -t ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ Then create a new branch off of main
 {
   "extensions": {
     "kubewarden": {
-      "repo": "kubewarden/ui",
+      "repo": "rancher/kubewarden-ui",
       "branch": "gh-pages",
       "versions": [
         "1.0.0",
-        "1.1.0"
+        "1.1.0",
+        "1.2.0
       ]
     }
   }
@@ -35,7 +36,7 @@ Then create a new branch off of main
 #### 3. Commit your changes
 ```bash
 git add manifest.json
-git commit -m "Submitting kubewarden/ui version 1.1.0"
+git commit -m "Submitting rancher/kubewarden-ui version 1.2.0"
 ```
 
 #### 4. Push your commit
@@ -50,13 +51,12 @@ Once your pull request is approved and merged, an automated workflow will sync t
 ### Configuration File
 
 Required properties for `manifest.json`
-| Variable | Description |
-| ------------- |------------- |
-| [extension key] | This name is representative of the Extension **package** name. For example, the [clock](https://github.com/rancher/ui-plugin-examples/tree/main/pkg/clock) package within the [`ui-plugin-examples`](https://github.com/rancher/ui-plugin-examples/tree/main) repository, `clock` would be the extension key.
-| repo | Defines the upstream **Github** repository to pull the build assets from.
-| branch | Defines which branch to pull from the upstream `repo`
-| versions | An array of version strings which correspond to the Extension **package** version(s) to be synced with this repository. For example, the [clock](https://github.com/rancher/ui-plugin-examples/tree/main/charts/clock) extension package has two versions, `0.1.0` and `0.2.0` would be added.
-
+| Property | Type | Description |
+| --------- | :---: | ------------- |
+| `[extension key]` | `Object` | This object is representative of the Extension **package** name. For example, the [clock](https://github.com/rancher/ui-plugin-examples/tree/main/pkg/clock) package within the [`ui-plugin-examples`](https://github.com/rancher/ui-plugin-examples/tree/main) repository, `clock` would be the extension key.
+| `repo` | `String` | Defines the upstream **Github** repository to pull the build assets from.
+| `branch` | `String` | Defines which branch to pull from the upstream `repo`
+| `versions` | `String[]` | An array of version strings which correspond to the Extension **package** version(s) to be synced with this repository. For example, the [clock](https://github.com/rancher/ui-plugin-examples/tree/main/charts/clock) extension package has two versions, `0.1.0` and `0.2.0` would be added.
 
 ### Examples
 
@@ -83,7 +83,8 @@ Required properties for `manifest.json`
         "1.0.4",
         "1.0.5",
         "1.0.6",
-        "1.1.0"
+        "1.1.0",
+        "1.2.0"
       ]
     }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
       ]
     },
     "kubewarden": {
-      "repo": "kubewarden/ui",
+      "repo": "rancher/kubewarden-ui",
       "branch": "gh-pages",
       "versions": [
         "1.0.0",

--- a/scripts/bundle-catalog
+++ b/scripts/bundle-catalog
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+BASE_DIR="$( cd $SCRIPT_DIR && cd .. & pwd)"
+
+CYAN="\033[96m"
+YELLOW="\033[93m"
+RESET="\033[0m"
+BOLD="\033[1m"
+NORMAL="\033[22m"
+CHECK="\xE2\x9C\x94"
+
+DEST_IMAGE_NAME="ui-plugin-catalog"
+DEST_TAG="latest"
+DEST_REGISTRY="ghcr.io"
+DEST_NAMESPACE="rancher"
+
+usage() {
+  echo "Usage: $0 [<options>]"
+  echo " options:"
+  echo "  -i, --image <name>            Specify the destination image name (defaults to 'ui-plugin-catalog')"
+  echo "  -t, --tag <name>              Specify the version tag for the destination image (defaults to 'latest')"
+  echo "  -r, --registry <name>         Specify the destination container registry to push the catalog images (defaults to 'ghcr.io')"
+  echo "  -n, --namespace <name>        Specify the destination namespace of the for the catalog image scope (defaults to 'rancher')"
+  exit 1
+}
+
+function missing_arg() {
+  if [[ -z $2 || $2 == -* ]]; then
+    echo "Error: Missing argument for $1 option"
+    usage
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      ;;
+    -i|--image)
+      missing_arg $1 $2
+      DEST_IMAGE_NAME="${2}"
+      shift 2
+      ;;
+    -t|--tag)
+      missing_arg $1 $2
+      DEST_TAG="${2}"
+      shift 2
+      ;;
+    -r|--registry)
+      missing_arg $1 $2
+      DEST_REGISTRY="${2}"
+      shift 2
+      ;;
+    -n|--namespace)
+      missing_arg $1 $2
+      DEST_NAMESPACE="${2}"
+      shift 2
+      ;;
+    *)
+      echo "Error: Unknown option $1"
+      usage
+      ;;
+  esac
+done
+
+shift $((OPTIND-1))
+
+echo -e "${CYAN}${BOLD}Syncing Extension Catalogs${RESET}"
+
+EXTS=$(jq -r ".extensions | keys[]" manifest.json)
+
+TMP=${BASE_DIR}/tmp
+rm -rf ${TMP}
+mkdir -p ${TMP}
+
+CONTAINER_TMP=${TMP}/_container
+
+# ============================================
+# Rebuild Helm charts and assets
+# ============================================
+for NAME in ${EXTS}
+do
+  echo -e "${CYAN} + Syncing: ${BOLD}${NAME}${RESET}"
+
+  REPO=$(jq -r ".extensions.${NAME}.repo" manifest.json)
+  EXT_BRANCH=$(jq -r ".extensions.${NAME}.branch" manifest.json)
+  VERSIONS=$(jq -r ".extensions.${NAME}.versions[]" manifest.json)
+  VFORMAT=$(echo $VERSIONS | tr '\n' ' ')
+
+  echo -e "     Repository: ${REPO}"
+  echo -e "     Branch: ${EXT_BRANCH}"
+  echo -e "     Versions  : ${VFORMAT}"
+  echo ""
+
+  echo -e "  .. Cloning repository"
+  rm -rf ${TMP}/${NAME}
+  pushd ${TMP} > /dev/null
+  git clone https://github.com/${REPO}.git ${NAME}
+  cd ${NAME}
+  git checkout ${EXT_BRANCH}
+  pwd
+  popd > /dev/null
+
+  for VERSION in ${VERSIONS}; do
+    echo -e "${CYAN}     Syncing: ${BOLD}${NAME}@${VERSION}${RESET}"
+
+    mkdir -p ${CONTAINER_TMP}/{assets,charts,extensions}/${NAME}
+
+    echo "     + Copying version ${VERSION}"
+    cp -R ./tmp/${NAME}/extensions/${NAME}/${VERSION} ${CONTAINER_TMP}/extensions/${NAME}
+    cp -R ./tmp/${NAME}/charts/${NAME}/${VERSION} ${CONTAINER_TMP}/charts/${NAME}
+
+    echo "     + Patching Helm chart"
+    CR_FILE=${CONTAINER_TMP}/charts/${NAME}/${VERSION}/templates/cr.yaml
+    ENDPOINT=http://${DEST_IMAGE_NAME}-svc.cattle-ui-plugin-system:8080/plugin/${NAME}-${VERSION}
+    sed -i.bak -e 's@endpoint:.*@endpoint: '"$ENDPOINT"'@' ${CR_FILE}
+    rm -f ${CR_FILE}.bak
+
+    echo "     + Fetching and patching icon"
+    CHART_FILE=${CONTAINER_TMP}/charts/${NAME}/${VERSION}/Chart.yaml
+    ICON=$(yq eval '.icon' ${CHART_FILE})
+    
+    if [[ -n "${ICON}" ]]; then
+      ICON_FILE=$(ls -1 "${CONTAINER_TMP}/extensions/${NAME}/${VERSION}/plugin/img" | head -n 1)
+      NEW_ICON=${ENDPOINT}/plugin/img/${ICON_FILE}
+
+      sed -i.bak -e 's@icon:.*@icon: '"$NEW_ICON"'@' ${CHART_FILE}
+
+      PKG_FILE=${CONTAINER_TMP}/extensions/${NAME}/${VERSION}/plugin/package.json
+      sed -i.bak -e 's@\"icon\": \".*\"@\"icon\": \"'"$NEW_ICON"'\"@' ${PKG_FILE}
+      rm -rf ${PKG_FILE}.bak
+    fi
+
+    echo "     + Packaging Helm chart"
+    helm package ${CONTAINER_TMP}/charts/${NAME}/${VERSION} -d ${CONTAINER_TMP}/assets/${NAME}
+
+    echo "     + Updating Helm index"
+    HELM_INDEX="${CONTAINER_TMP}/index.yaml"
+
+    if [ -f "${HELM_INDEX}" ]; then
+      UPDATE="--merge ${HELM_INDEX}"
+    fi
+
+    RELATIVE_URL="plugin/${NAME}"
+
+    helm repo index ${CONTAINER_TMP}/assets/${NAME} --url ${RELATIVE_URL} ${UPDATE}
+
+    mv ${CONTAINER_TMP}/assets/${NAME}/index.yaml ${CONTAINER_TMP}
+
+    # Move pkg files into relative named plugin directories
+    for d in ${CONTAINER_TMP}/extensions; do
+      pushd ${d}
+      mkdir -p ${NAME}-${VERSION}
+      mv ${NAME}/${VERSION}/* ${NAME}-${VERSION}
+      popd
+    done
+
+    rm -rf ${CONTAINER_TMP}/extensions/${NAME}
+  done
+
+  rm -rf ./tmp/${NAME}
+done
+
+# ============================================
+# Bundle extension assets into catalog image
+# ============================================
+PACKAGING_CONTAINER=${TMP}/container
+rm -rf ${PACKAGING_CONTAINER}
+mkdir -p ${PACKAGING_CONTAINER}
+
+# Fetch packaging scripts
+pushd ${PACKAGING_CONTAINER}
+git init
+git remote add subdir https://github.com/rancher/dashboard.git
+git fetch subdir
+git checkout subdir/master -- shell/scripts/extension/helm
+mv shell/scripts/extension/helm/* .
+rm -rf .git shell
+popd
+
+mkdir -p ${PACKAGING_CONTAINER}/plugin
+
+# Copy the plugin assets
+cp -R ${CONTAINER_TMP}/assets/* ${PACKAGING_CONTAINER}/plugin
+cp -R ${CONTAINER_TMP}/extensions/* ${PACKAGING_CONTAINER}/plugin
+cp ${CONTAINER_TMP}/index.yaml ${PACKAGING_CONTAINER}
+cp ${CONTAINER_TMP}/index.yaml ${PACKAGING_CONTAINER}/plugin
+
+cp ${BASE_DIR}/scripts/bundle/package.json ${PACKAGING_CONTAINER}/plugin
+
+PLUGIN_JSON=${PACKAGING_CONTAINER}/plugin/package.json
+cat ${PLUGIN_JSON} | jq '.name = $image_name' --arg image_name "${DEST_IMAGE_NAME}" | tee ${PLUGIN_JSON} >/dev/null
+cat ${PLUGIN_JSON} | jq '.version = $tagged_version' --arg tagged_version "${DEST_TAG}" | tee ${PLUGIN_JSON} >/dev/null
+
+pushd ${PACKAGING_CONTAINER} > /dev/null
+echo -e "${CYAN}Building container image ...${RESET}"
+
+IMAGE="${DEST_REGISTRY}/${DEST_NAMESPACE}/${DEST_IMAGE_NAME}:${DEST_TAG}"
+
+if [ ! -z "${DEST_REGISTRY}" ]; then
+  REGISTRY=${DEST_REGISTRY} ORG=${DEST_NAMESPACE} REPO=${DEST_IMAGE_NAME} TAG=${DEST_TAG} ./scripts/package
+
+  echo -e "${CYAN}Pushing container image ...${RESET}"
+
+  # Ensure that you do not overwrite production images
+  if [[ "${DEST_NAMESPACE}" == "rancher" ]]; then
+    if docker manifest inspect 2>&1 1>/dev/null; then
+      echo -e "${RED}${BOLD}Cannot overwrite production image ${DEST_IMAGE_NAME} since it already exists${RESET}"
+      exit 1
+    fi
+  fi
+
+  docker push ${IMAGE}
+fi
+
+popd > /dev/null
+
+rm -rf ${TMP}
+
+echo -e "${CHECK}${CYAN} ${IMAGE} has been successfully published.${RESET}"

--- a/scripts/bundle/package.json
+++ b/scripts/bundle/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ui-plugin-catalog",
+  "version": "0.1.0",
+  "private": false
+}

--- a/scripts/sync-charts
+++ b/scripts/sync-charts
@@ -64,7 +64,7 @@ if [[ $CLEAN == true ]]; then
   rm -rf ./icons
 fi
 
-echo -e "${CYAN}${BOLD}Syncing Extensions${RESET}"
+echo -e "${CYAN}${BOLD}Syncing Extension Charts${RESET}"
 
 EXTS=$(jq -r ".extensions | keys[]" manifest.json)
 


### PR DESCRIPTION
This will add a mechanism to build the Extension Catalog Image for the ui-plugin-charts repository. This image will consist of each extension and subsequent versions defined in the manifest.

Versioning of this catalog image will be accomplished by releasing a tag. The workflow is gated by a `released` trigger, the released tag that triggers this workflow will be the `tag` or version of the catalog image.

For example, cut a new release with a tag name `0.1.0`, this will trigger the workflow to build the image with that tag as the version.

I have created a [test image](https://hub.docker.com/layers/jordojordo/ui-plugin-catalog/0.1.2/images/sha256-5ccfc73fba40bd06b67f94448fb9c36e3a71a6994d46a82d89bc504edf2e4f64?context=explore) that can be used to import within the Rancher UI and will contain all of Kubewarden and Elemental versions.