### PR TITLE
Add token to git authentication for sync-extensions worklow

### DIFF
--- a/.github/workflows/sync-extensions.yml
+++ b/.github/workflows/sync-extensions.yml
@@ -26,9 +26,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BYPASS_TOKEN }} 
 
       - name: Configure Git
         run: |
+          echo ${{ secrets.BYPASS_TOKEN }} | gh auth login --with-token
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@github.com
       


### PR DESCRIPTION
This will add the `BYPASS_TOKEN` to the sync-extensions workflow to allow pushing new charts to the protected main branch. Example of failing action: https://github.com/rancher/ui-plugin-charts/actions/runs/6893204707/job/18752229063#step:7:55