### PR TITLE
Temporarily remove sync-charts trigger

### DIFF
--- a/.github/workflows/sync-extensions.yml
+++ b/.github/workflows/sync-extensions.yml
@@ -3,11 +3,12 @@ name: Sync and Release Extensions
 on:
   release:
     types: [released]
-  push:
-    branches:
-      - main
-    paths:
-      - manifest.json
+  # Removing this trigger until the protected rule on the `main` branch does not limit actions.
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - manifest.json
 
 env:
   ACTIONS_RUNNER_DEBUG: false


### PR DESCRIPTION
This will remove the trigger for running the `sync-charts` job within the workflow until we are able to push to the `main` branch from an action.