### PR TITLE
make elemental 1.3.0 bound to rancher 2.8.0

### DIFF
--- a/charts/elemental/1.3.0/Chart.yaml
+++ b/charts/elemental/1.3.0/Chart.yaml
@@ -4,7 +4,7 @@ annotations:
   catalog.cattle.io/namespace: cattle-ui-plugin-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows
-  catalog.cattle.io/rancher-version: '>= 2.7.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.8.0-0'
   catalog.cattle.io/scope: management
   catalog.cattle.io/ui-component: plugins
   catalog.cattle.io/ui-version: '>= 2.7.2'

--- a/index.yaml
+++ b/index.yaml
@@ -7,7 +7,7 @@ entries:
       catalog.cattle.io/namespace: cattle-ui-plugin-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/permits-os: linux, windows
-      catalog.cattle.io/rancher-version: '>= 2.7.0-0'
+      catalog.cattle.io/rancher-version: '>= 2.8.0-0'
       catalog.cattle.io/scope: management
       catalog.cattle.io/ui-component: plugins
       catalog.cattle.io/ui-version: '>= 2.7.2'


### PR DESCRIPTION
Fixes 

Make `elemental` `1.3.0` bound to rancher `2.8.0` as minimum version due to the fact that the `elemental-operator` on the marketplace is only available from `2.8.0` onwards

https://github.com/rancher/elemental-ui/issues/176