### PR TITLE
Fix parsing of extension name to include special characters

### DIFF
--- a/scripts/bundle-catalog
+++ b/scripts/bundle-catalog
@@ -84,9 +84,9 @@ for NAME in ${EXTS}
 do
   echo -e "${CYAN} + Syncing: ${BOLD}${NAME}${RESET}"
 
-  REPO=$(jq -r ".extensions.${NAME}.repo" manifest.json)
-  EXT_BRANCH=$(jq -r ".extensions.${NAME}.branch" manifest.json)
-  VERSIONS=$(jq -r ".extensions.${NAME}.versions[]" manifest.json)
+  REPO=$(jq -r ".extensions[\"${NAME}\"].repo" manifest.json)
+  EXT_BRANCH=$(jq -r ".extensions[\"${NAME}\"].branch" manifest.json)
+  VERSIONS=$(jq -r ".extensions[\"${NAME}\"].versions[]" manifest.json)
   VFORMAT=$(echo $VERSIONS | tr '\n' ' ')
 
   echo -e "     Repository: ${REPO}"


### PR DESCRIPTION
There is an issue with the bundle-catalog script which can not properly parse extension names with special characters, for example `neuvector-ui-ext`.

A [previous action failed](https://github.com/rancher/ui-plugin-charts/actions/runs/8803552097/job/24161959734#step:5:229) when syncing the neuvector extension:

<details open><summary><b>Sync Catalog Image with Registry step:</b></summary>

```console
 + Syncing: neuvector-ui-ext
jq: error: ui/0 is not defined at <top-level>, line 1:
.extensions.neuvector-ui-ext.repo                      
jq: error: ext/0 is not defined at <top-level>, line 1:
.extensions.neuvector-ui-ext.repo                         
jq: 2 compile errors
jq: error: ui/0 is not defined at <top-level>, line 1:
.extensions.neuvector-ui-ext.branch                      
jq: error: ext/0 is not defined at <top-level>, line 1:
.extensions.neuvector-ui-ext.branch                         
jq: 2 compile errors
jq: error: ui/0 is not defined at <top-level>, line 1:
.extensions.neuvector-ui-ext.versions[]                      
jq: error: ext/0 is not defined at <top-level>, line 1:
.extensions.neuvector-ui-ext.versions[]                         
jq: 2 compile errors
     Repository: 
     Branch: 
     Versions  :  

  .. Cloning repository
Cloning into 'neuvector-ui-ext'...
remote: Not Found
```

</details>

This can be fixed if the `NAME` key is enclosed in double quotes to ensure it is correctly parsed as a string:

<details open><summary><b>After:</b></summary>

```console
$ ./scripts/bundle-catalog -t test-tag
Syncing Extension Catalogs
 + Syncing: neuvector-ui-ext
     Repository: neuvector/manager-ext
     Branch: gh-pages
     Versions  : 1.0.0 

  .. Cloning repository
Cloning into 'neuvector-ui-ext'...
```

</details>
