### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
       "repo": "StackVista/rancher-extension-stackstate",
       "branch": "gh-pages",
       "versions": [
+        "0.2.0",
         "0.5.0"
       ]
     },

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
       "repo": "StackVista/rancher-extension-stackstate",
       "branch": "gh-pages",
       "versions": [
+        "0.2.1,
         "0.5.0",
         "1.0.0"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
       "repo": "StackVista/rancher-extension-stackstate",
       "branch": "gh-pages",
       "versions": [
-        "0.2.1,
+        "0.2.1",
         "0.5.0",
         "1.0.0"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
       "repo": "StackVista/rancher-extension-stackstate",
       "branch": "gh-pages",
       "versions": [
-        "0.2.0",
-        "0.5.0"
+        "0.5.0",
+        "1.0.0"
       ]
     },
     "neuvector-ui-ext": {


### PR DESCRIPTION
Include observability@0.2.0.

The [documentation page](https://docs.stackstate.com/get-started/k8s-suse-rancher-prime#open-issues) mentions support for rancher 2.8.x but the official rancher plugin range does not include the observability version for 2.8 rancher 

### UPD Nov 6

It includes `1.0.0` GA version as well.