### PR TITLE
patch extensions part of sync procedure + some fixes

### DIFF
--- a/.github/workflows/sync-extensions.yml
+++ b/.github/workflows/sync-extensions.yml
@@ -46,6 +46,14 @@ jobs:
         run: |
           chmod +x ./scripts/sync-charts
           ./scripts/sync-charts
+      
+
+      - name: Run patch extensions script
+        shell: bash
+        id: patch_extensions_script
+        run: |
+          chmod +x ./scripts/patch-extensions
+          ./scripts/patch-extensions
 
       - name: Generate branch name based on date and time
         run: echo "NOW=$(date +'%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV

--- a/.github/workflows/sync-extensions.yml
+++ b/.github/workflows/sync-extensions.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Commit Changes and push to a branch
         run: |
           git checkout -b sync-${{ env.NOW }}
-          git add ./{assets,charts,extensions,icons,index.yaml}
+          git add ./{assets,charts,extensions,icons,index.yaml,.patched.json}
           git commit -a -m "Sync extensions ${{ env.NOW }}"
           git push origin sync-${{ env.NOW }}
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,11 @@ We now provide the ability to change metadata on published extensions in this re
 ```
 - the `versions` semver check will only apply the changes to the interval (or simple condition) that you want to
 - the `dir` folder is the name of the folder **inside** `elemental` folder, where file assets like `README` and `icon` will live, which will be applied as patch
-- **Caveat**: for the **ICON** change, the icon file must be called `icon` (it doesn't care about the file extension, since it can be a `svg` or `png`) in order for it to be considered as change
-- **Caveat**: for the **README** change: the file content must be different than the `README` originally present on the extension in order to be applied, otherwise it's ignored
+
+### Caveats
+
+- For the **ICON** change, the icon file must be called `icon` (it doesn't care about the file extension, since it can be a `svg` or `png`) in order for it to be considered as change
+- For the **README** change: the file content must be different than the `README` originally present on the extension in order to be applied, otherwise it's ignored
 
 
 ### How does the script work
@@ -142,3 +145,22 @@ We now provide the ability to change metadata on published extensions in this re
 - if it matches, then it starts by doing checks on whether to apply any of the above changes and creates "APPLY" flags for each different metadata change
 - after all checks are done, it's time to apply them. Starts by unpacking the TGZ and changing all the metadata we've check before both outside the TGZ assets and inside them as well
 - once all changes are done, repacks the TGZ, applies the same permissions as the original file and regens the `index.yaml`
+
+## Running the patch-extensions script
+
+The `patch-extensions` script can be run with optional arguments to override the default repository organization and branch:
+
+```bash
+# Default: uses rancher organization and main branch
+./scripts/patch-extensions
+
+# Custom organization and branch (useful for testing/previewing on forks)
+./scripts/patch-extensions aalves08 15413-update-names-extensions-test
+
+# Only override organization
+./scripts/patch-extensions your-github-username
+```
+
+**Parameters:**
+- `$1` (optional): GitHub organization name (default: `rancher`)
+- `$2` (optional): Branch name (default: `main`)

--- a/README.md
+++ b/README.md
@@ -164,3 +164,60 @@ The `patch-extensions` script can be run with optional arguments to override the
 **Parameters:**
 - `$1` (optional): GitHub organization name (default: `rancher`)
 - `$2` (optional): Branch name (default: `main`)
+
+## Patching as Part of the Sync Mechanism
+
+The `patch-extensions` script is now automatically executed as part of the sync workflow. This means that whenever extensions are synced into the repository, any patches defined for those extensions are applied immediately.
+
+### Automated Sync Workflow
+
+1. When `manifest.json` is updated on the `main` branch, a GitHub Actions workflow triggers automatically
+2. The workflow syncs extension assets from upstream repositories
+3. The `patch-extensions` script runs automatically to apply any configured patches
+4. All changes (synced assets + patches) are committed together in a single PR
+
+This ensures that patches are always applied consistently and are never missed during the sync process.
+
+## Preventing Duplicate Patching with `.patched.json`
+
+To prevent the same extension@version from being patched multiple times across syncs, the system maintains a `.patched.json` file that tracks which extensions have already been patched.
+
+### How `.patched.json` Works
+
+When patches are applied, an entry is automatically added to `.patched.json` with a timestamp:
+
+```json
+{
+  "observability@2.3.1": "2026-05-14T16:38:04Z",
+  "stackvista@1.0.0": "2026-05-14T16:38:04Z",
+  "kubewarden@4.1.1": "2026-05-14T12:00:00Z"
+}
+```
+
+**Behavior:**
+- **First sync**: Extensions matching patch conditions are patched and logged to `.patched.json`
+- **Subsequent syncs**: Extensions already in `.patched.json` are skipped (not re-patched)
+- The `.patched.json` file is committed as part of the workflow, ensuring all environments stay in sync
+
+### Re-patching an Extension
+
+If you need to re-patch an extension that was previously patched:
+
+1. **Remove the entry** from `.patched.json`:
+   ```bash
+   # Edit .patched.json and remove the line:
+   # "observability@2.3.1": "2026-05-14T16:38:04Z",
+   ```
+
+2. **Update your patch definition** in `patches/[extension]/patches.json` as needed
+
+3. **Commit both changes** and push
+   ```bash
+   git add .patched.json patches/[extension]/patches.json
+   git commit -m "Re-patch observability@2.3.1"
+   git push
+   ```
+
+4. The next sync will re-apply the patches to that extension@version
+
+This explicit removal approach ensures that re-patching is intentional and visible in git history.

--- a/scripts/patch-extensions
+++ b/scripts/patch-extensions
@@ -19,6 +19,13 @@ BRANCH="${2:-main}"
 echo -e "${CYAN}${BOLD}Patch mechanism for extensions${RESET}"
 echo -e "${CYAN}ORG: ${ORG}, BRANCH: ${BRANCH}${RESET}"
 
+# Initialize or load .patched.json
+PATCHED_FILE="${BASE_DIR}/.patched.json"
+if [ ! -f "$PATCHED_FILE" ]; then
+  echo "{}" > "$PATCHED_FILE"
+  echo -e "${CYAN}Created $PATCHED_FILE${RESET}"
+fi
+
 EXTS_ARRAY=()
 while IFS= read -r EXT; do
     EXTS_ARRAY+=("$EXT")
@@ -105,8 +112,16 @@ do
   echo -e "     Versions  : ${VFORMAT}"
   echo ""
 
-  for VERSION in "${VERSIONS_ARRAY[@]}" 
+  for VERSION in "${VERSIONS_ARRAY[@]}"
   do
+    EXTENSION_KEY="${NAME}@${VERSION}"
+
+    # Check if this extension@version has already been patched
+    if jq -e ".\"$EXTENSION_KEY\"" "$PATCHED_FILE" > /dev/null 2>&1; then
+      echo -e "${PURPLE}     Skipping: ${BOLD}${EXTENSION_KEY}${RESET} (already patched)${RESET}"
+      continue
+    fi
+
     echo -e "${CYAN}     Syncing: ${BOLD}${NAME}@${VERSION}${RESET}"
 
     if [ -d "./patches/${NAME}" ]; then
@@ -631,6 +646,11 @@ do
           else
             echo -e "${PURPLE}Nothing to do with assets/.tgz file...${RESET}"
           fi
+
+          # Log the patched extension with timestamp
+          TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          jq ".\"$EXTENSION_KEY\" = \"$TIMESTAMP\"" "$PATCHED_FILE" > "${PATCHED_FILE}.tmp" && mv "${PATCHED_FILE}.tmp" "$PATCHED_FILE"
+          echo -e "${GREEN}Logged ${EXTENSION_KEY} to ${PATCHED_FILE}${RESET}"
 
           echo "---------------------------------------------------------"
           echo "--- Traversal Complete ---"

--- a/scripts/patch-extensions
+++ b/scripts/patch-extensions
@@ -12,10 +12,12 @@ RED="\033[31m"
 RESET="\033[0m"
 BOLD="\033[1m"
 
-ORG=rancher
-BRANCH=main
+# Default values (can be overridden via command-line arguments)
+ORG="${1:-rancher}"
+BRANCH="${2:-main}"
 
 echo -e "${CYAN}${BOLD}Patch mechanism for extensions${RESET}"
+echo -e "${CYAN}ORG: ${ORG}, BRANCH: ${BRANCH}${RESET}"
 
 EXTS_ARRAY=()
 while IFS= read -r EXT; do
@@ -379,9 +381,8 @@ do
             # handle ICON
             if [[ "$APPLY_ICON" == "true" ]]; then
               # copy ICON to icons folder
-              SOURCE_FOLDER="${BASE_PATCH_DIR}/${DIR}" 
-              DEST_FOLDER="./icons/${NAME}"             
-              NEW_ICON_NAME="patched-icon-${NAME}-${VERSION}"               
+              SOURCE_FOLDER="${BASE_PATCH_DIR}/${DIR}"
+              DEST_FOLDER="./icons/${NAME}"
 
               # Use the glob pattern to reliably capture the full filename
               MAPFILE=("${SOURCE_FOLDER}/${BASE_ICON_NAME}."*)
@@ -392,16 +393,34 @@ do
               EXTENSION="${SOURCE_PATH##*.}"
               echo "Extracted extension of ICON: .${EXTENSION}"
 
+              # Detect icon naming pattern from the most recent existing icon in the folder
+              EXISTING_ICON=$(ls "$DEST_FOLDER" | grep -v patched | sort -V | tail -1)
+              if [[ -n "$EXISTING_ICON" ]]; then
+                # Extract suffix from existing icon name (e.g., from "1.6.0-icon.svg" extract "-icon")
+                ICON_SUFFIX=$(echo "$EXISTING_ICON" | sed "s/^[0-9.]*//" | sed "s/\.[^.]*$//")
+                echo "Detected icon suffix pattern from latest icon: $ICON_SUFFIX"
+              else
+                # Fallback to generic pattern if no existing icons found
+                ICON_SUFFIX="-icon"
+              fi
+
+              NEW_ICON_NAME="${VERSION}${ICON_SUFFIX}"
+
               # Construct the full destination path
-              # Example: /tmp/elemental/icon.svg
               DEST_PATH="${DEST_FOLDER}/${NEW_ICON_NAME}.${EXTENSION}"
-              
+
               # Perform the copy and rename operation
-              if cp -fr "$SOURCE_PATH" "$DEST_PATH"; then
-                echo -e "${GREEN}ICON ::: Icon file copied and renamed to $NEW_ICON_NAME.${EXTENSION} in temp folder.${RESET}"
+              if cp -f "$SOURCE_PATH" "$DEST_PATH"; then
+                echo -e "${GREEN}ICON ::: Icon file copied to $NEW_ICON_NAME.${EXTENSION} in icons folder.${RESET}"
               else
                 echo -e "${RED}ICON ::: Failed to copy icon file from $SOURCE_PATH to $DEST_PATH.${RESET}"
               fi
+
+              # Update icon inside the extracted tgz folder (keep original name)
+              TMP_ICON_DIR="${TMP}/${NAME}"
+              find "$TMP_ICON_DIR" -maxdepth 1 -name "icon.*" -delete
+              cp -f "$SOURCE_PATH" "${TMP_ICON_DIR}/icon.${EXTENSION}"
+              echo -e "${GREEN}ICON ::: Icon file updated in extracted tgz folder.${RESET}"
 
               # new icon path
               NEW_ICON_PATH="https://raw.githubusercontent.com/${REPOSITORY}/${BRANCH}/icons/${NAME}/${NEW_ICON_NAME}.${EXTENSION}"
@@ -598,6 +617,7 @@ do
 
             # --- Cleanup ---
             rm -rf "$TMP"
+            mkdir -p "$TMP"
             echo "Cleaned up temporary directory: $TMP"
 
             # since we've updated annotations, we need to regenerate index.yaml


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/17636

- fix some know issues of patching mechanism with icons
- add functionality to patching mechanism to be able to run it (manually) to a given ORG + BRANCH
- add a patched log file to record what `extension@version `were patched to prevent re-patching the same extension again and again
- add patching mechanism to be part of the sync extension mechanism
- update README with the information above