### PR TITLE
remove version of vuln scanner without prime-only annotation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,6 @@
       "repo": "neuvector/security-ui-exts",
       "branch": "gh-pages",
       "versions": [
-        "0.8.0",
         "0.8.1"
       ]
     },


### PR DESCRIPTION
- remove version of vuln scanner without prime-only annotation